### PR TITLE
removed type

### DIFF
--- a/src/combination.jl
+++ b/src/combination.jl
@@ -105,7 +105,7 @@ function combin2drugs(
     named1::String,
     named2::String,
     effs::Array{Float64, 3},
-    blissNum::Array{Float64, 2},
+    blissNum,
     g0::Float64,
 )
     n=8


### PR DESCRIPTION
The pdf file was not being generated correctly, because I was passing the transpose of a matrix which didn't match the type. I just removed the type in the function argument. Now all the combinations should be plotted.