### PR TITLE
More cleanup

### DIFF
--- a/notebookPlots.jmd
+++ b/notebookPlots.jmd
@@ -31,7 +31,7 @@ effects3 = getODEparams(ps3, concs[:, 1]);
 ```
 
 ```julia
-G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, concs[:, 1], g0); # for lapatinib
+G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for lapatinib
 ```
 
 ## Lapatinib
@@ -73,7 +73,7 @@ effects3 = getODEparams(p3, concs[:, 2]);
 ```
 
 ```julia
-G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, concs[:, 2], g0); # for doxorubicin
+G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for doxorubicin
 ```
 
 ```julia
@@ -116,7 +116,7 @@ effects3 = getODEparams(p3, concs[:, 3]);
 ```
 
 ```julia
-G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, concs[:, 3], g0); # for Gemcitabine
+G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for Gemcitabine
 ```
 
 ```julia
@@ -155,7 +155,7 @@ effects3 = getODEparams(p3, concs[:, 4]);
 ```
 
 ```julia
-G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, concs[:, 4], g0); # for Paclitaxel
+G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for Paclitaxel
 ```
 
 ```julia
@@ -194,7 +194,7 @@ effects3 = getODEparams(p3, concs[:, 5]);
 ```
 
 ```julia
-G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, concs[:, 2], g0); # for Palbociclib
+G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for Palbociclib
 ```
 
 ```julia

--- a/notebookPlots.jmd
+++ b/notebookPlots.jmd
@@ -31,14 +31,14 @@ effects3 = getODEparams(ps3, concs[:, 1]);
 ```
 
 ```julia
-G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for lapatinib
+G1, G2 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for lapatinib
 ```
 
 ## Lapatinib
 ### Plotting the time-series simulations compared to the actual data for three replicates.
 
 ```julia
-pl = [DrugResponseModel.plot2(G1_1[:, i], G1_2[:, i], G1_3[:, i], G2_1[:, i], G2_2[:, i], G2_3[:, i], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, i, 1) for i=1:8]
+pl = [DrugResponseModel.plot2(G1[:, i, :], G2[:, i, :], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, i, 1) for i=1:8]
 plot(pl..., size=(1000,700))
 ```
 
@@ -73,11 +73,11 @@ effects3 = getODEparams(p3, concs[:, 2]);
 ```
 
 ```julia
-G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for doxorubicin
+G1, G2 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for doxorubicin
 ```
 
 ```julia
-pl = [DrugResponseModel.plot2(G1_1[:, i], G1_2[:, i], G1_3[:, i], G2_1[:, i], G2_2[:, i], G2_3[:, i], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, i, 2) for i=1:8]
+pl = [DrugResponseModel.plot2(G1[:, i, :], G2[:, i, :], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, i, 2) for i=1:8]
 plot(pl..., size=(1000,700))
 ```
 
@@ -116,11 +116,11 @@ effects3 = getODEparams(p3, concs[:, 3]);
 ```
 
 ```julia
-G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for Gemcitabine
+G1, G2 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for Gemcitabine
 ```
 
 ```julia
-pl = [DrugResponseModel.plot2(G1_1[:, i], G1_2[:, i], G1_3[:, i], G2_1[:, i], G2_2[:, i], G2_3[:, i], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, i, 3) for i=1:8]
+pl = [DrugResponseModel.plot2(G1[:, i, :], G2[:, i, :], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, i, 3) for i=1:8]
 plot(pl..., size=(1000,700))
 ```
 
@@ -155,11 +155,11 @@ effects3 = getODEparams(p3, concs[:, 4]);
 ```
 
 ```julia
-G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for Paclitaxel
+G1, G2 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for Paclitaxel
 ```
 
 ```julia
-pl = [DrugResponseModel.plot2(G1_1[:, i], G1_2[:, i], G1_3[:, i], G2_1[:, i], G2_2[:, i], G2_3[:, i], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, i, 4) for i=1:8]
+pl = [DrugResponseModel.plot2(G1[:, i, :], G2[:, i, :], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, i, 4) for i=1:8]
 plot(pl..., size=(1000,700))
 ```
 
@@ -194,11 +194,11 @@ effects3 = getODEparams(p3, concs[:, 5]);
 ```
 
 ```julia
-G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for Palbociclib
+G1, G2 = DrugResponseModel.predict_replicates(effects1, effects2, effects3, g0); # for Palbociclib
 ```
 
 ```julia
-pl = [DrugResponseModel.plot2(G1_1[:, i], G1_2[:, i], G1_3[:, i], G2_1[:, i], G2_2[:, i], G2_3[:, i], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, i, 5) for i=1:8]
+pl = [DrugResponseModel.plot2(G1[:, i, :], G2[:, i, :], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, i, 5) for i=1:8]
 plot(pl..., size=(1000,700))
 ```
 

--- a/replicatesAtOnce.jmd
+++ b/replicatesAtOnce.jmd
@@ -44,18 +44,14 @@ ef3 = getODEparamsAll(rep3, concs);
 ```
 
 ```julia
-G1_1 = zeros(189, 8, 5)
-G1_2 = zeros(189, 8, 5)
-G1_3 = zeros(189, 8, 5)
-G2_1 = zeros(189, 8, 5)
-G2_2 = zeros(189, 8, 5)
-G2_3 = zeros(189, 8, 5)
+G1 = zeros(189, 8, 3, 5)
+G2 = zeros(189, 8, 3, 5)
 for i=1:5
-    G1_1[:, :, i], G2_1[:, :, i], G1_2[:, :, i], G2_2[:, :, i], G1_3[:, :, i], G2_3[:, :, i] = DrugResponseModel.predict_replicates(ef1[:, :, i], ef2[:, :, i], ef3[:, :, i], g0)
+    G1[:, :, :, i], G2[:, :, :, i] = DrugResponseModel.predict_replicates(ef1[:, :, i], ef2[:, :, i], ef3[:, :, i], g0)
 end
 
 j=1
-pl = [DrugResponseModel.plot2(G1_1[:, i, j], G1_2[:, i, j], G1_3[:, i, j], G2_1[:, i, j], G2_2[:, i, j], G2_3[:, i, j], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, concs[i, j], i, j) for i=1:8]
+pl = [DrugResponseModel.plot2(G1[:, i, :, j], G2[:, i, :, j], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, concs[i, j], i, j) for i=1:8]
 plot(pl..., size=(1000,700))
 ```
 
@@ -74,7 +70,7 @@ end
 ## Lapatinib
 ```julia
 j=1
-pl = [DrugResponseModel.plot2(G1_1[:, i, j], G1_2[:, i, j], G1_3[:, i, j], G2_1[:, i, j], G2_2[:, i, j], G2_3[:, i, j], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, concs[i, j], i, j) for i=1:8]
+pl = [DrugResponseModel.plot2(G1[:, i, :, j], G2[:, i, :, j], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, concs[i, j], i, j) for i=1:8]
 plot(pl..., size=(1000,700))
 ```
 
@@ -87,7 +83,7 @@ DrugResponseModel.plot_parameters(concs[:, 1], avgs[:, :, 1], stds[:, :, 1])
 
 ```julia
 j=2
-pl = [DrugResponseModel.plot2(G1_1[:, i, j], G1_2[:, i, j], G1_3[:, i, j], G2_1[:, i, j], G2_2[:, i, j], G2_3[:, i, j], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, concs[i, j], i, j) for i=1:8]
+pl = [DrugResponseModel.plot2(G1[:, i, :, j], G2[:, i, :, j], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, concs[i, j], i, j) for i=1:8]
 plot(pl..., size=(1000,700))
 ```
 
@@ -99,7 +95,7 @@ DrugResponseModel.plot_parameters(concs[:, 2], avgs[:, :, 2], stds[:, :, 2])
 
 ```julia
 j=3
-pl = [DrugResponseModel.plot2(G1_1[:, i, j], G1_2[:, i, j], G1_3[:, i, j], G2_1[:, i, j], G2_2[:, i, j], G2_3[:, i, j], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, concs[i, j], i, j) for i=1:8]
+pl = [DrugResponseModel.plot2(G1[:, i, :, j], G2[:, i, :, j], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, concs[i, j], i, j) for i=1:8]
 plot(pl..., size=(1000,700))
 ```
 
@@ -111,7 +107,7 @@ DrugResponseModel.plot_parameters(concs[:, 3], avgs[:, :, 3], stds[:, :, 3])
 
 ```julia
 j=4
-pl = [DrugResponseModel.plot2(G1_1[:, i, j], G1_2[:, i, j], G1_3[:, i, j], G2_1[:, i, j], G2_2[:, i, j], G2_3[:, i, j], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, concs[i, j], i, j) for i=1:8]
+pl = [DrugResponseModel.plot2(G1[:, i, :, j], G2[:, i, :, j], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, concs[i, j], i, j) for i=1:8]
 plot(pl..., size=(1000,700))
 ```
 
@@ -123,7 +119,7 @@ DrugResponseModel.plot_parameters(concs[:, 4], avgs[:, :, 4], stds[:, :, 4])
 
 ```julia
 j=5
-pl = [DrugResponseModel.plot2(G1_1[:, i, j], G1_2[:, i, j], G1_3[:, i, j], G2_1[:, i, j], G2_2[:, i, j], G2_3[:, i, j], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, concs[i, j], i, j) for i=1:8]
+pl = [DrugResponseModel.plot2(G1[:, i, :, j], G2[:, i, :, j], g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, concs[i, j], i, j) for i=1:8]
 plot(pl..., size=(1000,700))
 ```
 

--- a/replicatesAtOnce.jmd
+++ b/replicatesAtOnce.jmd
@@ -51,7 +51,7 @@ G2_1 = zeros(189, 8, 5)
 G2_2 = zeros(189, 8, 5)
 G2_3 = zeros(189, 8, 5)
 for i=1:5
-    G1_1[:, :, i], G2_1[:, :, i], G1_2[:, :, i], G2_2[:, :, i], G1_3[:, :, i], G2_3[:, :, i] = DrugResponseModel.predict_replicates(ef1[:, :, i], ef2[:, :, i], ef3[:, :, i], concs[:,i], g0)
+    G1_1[:, :, i], G2_1[:, :, i], G1_2[:, :, i], G2_2[:, :, i], G1_3[:, :, i], G2_3[:, :, i] = DrugResponseModel.predict_replicates(ef1[:, :, i], ef2[:, :, i], ef3[:, :, i], g0)
 end
 
 j=1

--- a/src/replicates.jl
+++ b/src/replicates.jl
@@ -9,7 +9,7 @@ function predict_replicates(p1, p2, p3, g0)
 
     for i = 1:size(ps, 2) # concentration number
         for j = 1:size(ps, 3)
-            G1[:, i, j], G2[:, i, j], _ = predict(p1[:, i, j], g0, t)
+            G1[:, i, j], G2[:, i, j], _ = predict(ps[:, i, j], g0, t)
         end
     end
 

--- a/src/replicates.jl
+++ b/src/replicates.jl
@@ -1,36 +1,25 @@
 """ This file includes functions to calculate values related to replicates. """
 
 ### A function to predict G1 and G2 for the three replicates.###
-function predict_replicates(p1, p2, p3, concs1, g0)
-
+function predict_replicates(p1, p2, p3, g0)
     t = LinRange(0.0, 95.0, 189)
-    G1_1 = ones(189, 8)
-    G2_1 = ones(189, 8)
-    G1_2 = ones(189, 8)
-    G2_2 = ones(189, 8)
-    G1_3 = ones(189, 8)
-    G2_3 = ones(189, 8)
+    ps = cat(p1, p2, p3, dims = 3)
+    G1 = ones(189, 8, 3)
+    G2 = ones(189, 8, 3)
 
-    for i = 1:8 # concentration number
-        G1_1[:, i], G2_1[:, i], _ = predict(p1[:, i], g0, t)
-        G1_2[:, i], G2_2[:, i], _ = predict(p2[:, i], g0, t)
-        G1_3[:, i], G2_3[:, i], _ = predict(p3[:, i], g0, t)
+    for i = 1:size(ps, 2) # concentration number
+        for j = 1:size(ps, 3)
+            G1[:, i, j], G2[:, i, j], _ = predict(p1[:, i, j], g0, t)
+        end
     end
 
-    return G1_1, G2_1, G1_2, G2_2, G1_3, G2_3 # all simulation
+    return G1[:, :, 1], G1[:, :, 2], G1[:, :, 3], G2[:, :, 1], G2[:, :, 2], G2[:, :, 3] # all simulation
 end
 
 """ A function to calculate std and mean of ODE parameters for each drug. """
 function mean_std_params(effs1, effs2, effs3)
-    meann = ones(9, 8)
-    stdd = ones(9, 8)
-    for i = 1:8
-        for j = 1:9
-            meann[j, i] = mean([effs1[j, i], effs2[j, i], effs3[j, i]])
-            stdd[j, i] = std([effs1[j, i], effs2[j, i], effs3[j, i]])
-        end
-    end
-    return meann, stdd
+    eff = cat(effs1, effs2, effs3, dims = 3)
+    return mean(eff, dims = 3), std(eff, dims = 3)
 end
 
 """ Calculate the # of cells in G1 for a set of parameters and T """

--- a/src/replicates.jl
+++ b/src/replicates.jl
@@ -13,7 +13,7 @@ function predict_replicates(p1, p2, p3, g0)
         end
     end
 
-    return G1[:, :, 1], G2[:, :, 1], G1[:, :, 2], G2[:, :, 2], G1[:, :, 3], G2[:, :, 3] # all simulation
+    return G1, G2 # all simulation
 end
 
 """ A function to calculate std and mean of ODE parameters for each drug. """
@@ -35,14 +35,14 @@ end
 
 
 """ plots all the three simulated trials. Along with avg and std of data. """
-function plot2(G1_1, G1_2, G1_3, G2_1, G2_2, G2_3, g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, conc, i, j)
+function plot2(G1, G2, g1s1, g1s2, g1s3, g2s1, g2s2, g2s3, conc, i, j)
     time = LinRange(0.0, 95.0, 189)
-    G1 = cat(g1s1, g1s2, g1s3, dims = 4)
-    G2 = cat(g2s1, g2s2, g2s3, dims = 4)
-    meang1 = mean(G1, dims = 4)
-    meang2 = mean(G2, dims = 4)
-    stdg1 = std(G1, dims = 4)
-    stdg2 = std(G2, dims = 4)
+    G1s = cat(g1s1, g1s2, g1s3, dims = 4)
+    G2s = cat(g2s1, g2s2, g2s3, dims = 4)
+    meang1 = mean(G1s, dims = 4)
+    meang2 = mean(G2s, dims = 4)
+    stdg1 = std(G1s, dims = 4)
+    stdg2 = std(G2s, dims = 4)
 
     plot(
         time,
@@ -55,12 +55,12 @@ function plot2(G1_1, G1_2, G1_3, G2_1, G2_2, G2_3, g1s1, g1s2, g1s3, g2s1, g2s2,
         ylabel = "cell number",
         alpha = 0.1,
     )
-    plot!(time, G1_1, label = "G1", color = 6)
-    plot!(time, G1_2, label = "", color = 6)
-    plot!(time, G1_3, label = "", color = 6)
+    plot!(time, G1[:, 1], label = "G1", color = 6)
+    plot!(time, G1[:, 2], label = "", color = 6)
+    plot!(time, G1[:, 3], label = "", color = 6)
     plot!(time, meang2[:, i, j]; ribbon = stdg2[:, i, j], color = 7, label = "", alpha = 0.1)
-    plot!(time, G2_1, label = "G2", color = 7)
-    plot!(time, G2_2, label = "", color = 7)
-    plot!(time, G2_3, label = "", color = 7)
+    plot!(time, G2[:, 1], label = "G2", color = 7)
+    plot!(time, G2[:, 2], label = "", color = 7)
+    plot!(time, G2[:, 3], label = "", color = 7)
     ylims!((0.0, 45))
 end

--- a/src/replicates.jl
+++ b/src/replicates.jl
@@ -13,7 +13,7 @@ function predict_replicates(p1, p2, p3, g0)
         end
     end
 
-    return G1[:, :, 1], G1[:, :, 2], G1[:, :, 3], G2[:, :, 1], G2[:, :, 2], G2[:, :, 3] # all simulation
+    return G1[:, :, 1], G2[:, :, 1], G1[:, :, 2], G2[:, :, 2], G1[:, :, 3], G2[:, :, 3] # all simulation
 end
 
 """ A function to calculate std and mean of ODE parameters for each drug. """


### PR DESCRIPTION
Ok, this is mostly an example of some more widespread cleanup that's badly needed.

You should almost never need to pass identically structured arrays like `g1_1, g1_2, g1_3`. Instead, these should be concatenated along a new dimension. In fact, the G1 and G2 data is always passed around together, so these should be combined into an array with another dimension of size 2.

The consequence of these is much easier to read code. In addition to reducing the number of variables, this will allow for broadcasting to that you don't need loops with complicated indexing. If you're concerned with making sure the data is matched up, you can always add type information to make sure the Array is 2, 3, 4... dimensional, and assertions to enforce that a dimension is a specific size.